### PR TITLE
Remove binary sample images and clarify docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ data/sample/train/
 # local‐mode outputs
 sagemaker-*
 output/
+
+# example images
+examples/

--- a/README.md
+++ b/README.md
@@ -109,6 +109,17 @@ This project includes an interactive Gradio app for making predictions with the 
     python gradio_app.py
     ```
 - The app will start locally and print a link (e.g., `http://127.0.0.1:7860`) to access the web UI in your browser.
+## Deploying on Hugging Face Spaces
+1. Create a new Gradio Space on [Hugging Face](https://huggingface.co/spaces).
+2. Upload the following files from this repo:
+   - `gradio_app.py`
+   - `requirements.txt`
+   - `class_names.txt`
+   - `config/prod.yaml`
+   - `output/model.pth`
+   - *(optional)* an `examples/` folder with sample images for the Gradio UI
+3. Commit and push to the Space. Hugging Face will build and launch the app.
+
 
 ## Requirements
 - See `requirements.txt`


### PR DESCRIPTION
## Summary
- delete example images
- ignore future `examples/` folders
- handle missing examples gracefully in `gradio_app.py`
- document optional sample images for Hugging Face Spaces

## Testing
- `ruff check gradio_app.py`
- `python -m py_compile gradio_app.py`


------
https://chatgpt.com/codex/tasks/task_e_683f99106b788332a27ef94e42fea09b