### PR TITLE
Add pre-commit and pytest scaffolding

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.0
+    hooks:
+      - id: ruff

--- a/README.md
+++ b/README.md
@@ -165,6 +165,21 @@ Update only your config file (not hardcoded values) when changing image size or 
 - Python >= 3.9
 - PyTorch >= 2.6
 
+## Development
+Install the developer tools and set up `pre-commit` hooks:
+
+```bash
+pip install -r requirements-dev.txt
+pre-commit install
+```
+
+Run formatting, linting, and tests with:
+
+```bash
+pre-commit run --all-files
+pytest
+```
+
 ## Contributing
 Open to issues and pull requests!
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+black
+ruff
+pytest
+pre-commit

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from train import ensure_unpacked
+
+
+def test_ensure_unpacked_noop(tmp_path):
+    d = tmp_path / "data"
+    d.mkdir()
+    (d / "file.txt").write_text("hi")
+    assert ensure_unpacked(str(d)) == str(d)


### PR DESCRIPTION
## Summary
- add `.pre-commit-config.yaml` with black and ruff
- provide dev requirements and example test
- document development steps in README

## Testing
- `pre-commit run --files README.md requirements-dev.txt .pre-commit-config.yaml tests/test_train.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_683fb08341c4833288e385041c35e627